### PR TITLE
Update domain and favicon references

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -9,32 +9,113 @@ export default defineConfig({
     ]
   },
   sitemap: {
-    hostname: 'https://docs.truenetwork.io'
+    hostname: 'https://truenetwork.io'
   },
 
   head: [
-    ['link', { rel: 'icon', href: '/assets/symbol.png' }], 
-    ['title', {}, 'True Network Docs: Attest & Score On-Chain Easily.'],
-    
+    ['link', { rel: 'icon', type: 'image/png', href: '/symbol.png' }],
+    ['link', { rel: 'apple-touch-icon', href: '/symbol.png' }],
+    ['link', { rel: 'manifest', href: '/site.webmanifest' }],
+    ['meta', { name: 'theme-color', content: '#ff4000' }],
+    ['meta', { name: 'msapplication-TileColor', content: '#ff4000' }],
+    ['meta', { name: 'robots', content: 'index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' }],
+    ['meta', { name: 'keywords', content: 'True Network, on-chain attestations, reputation scoring, web3 infrastructure, crypto attestations, decentralized reputation' }],
+    ['meta', { name: 'author', content: 'True Network' }],
+    ['meta', { property: 'og:site_name', content: 'True Network Docs' }],
     ['meta', { property: 'og:type', content: 'website' }],
-    ['meta', { property: 'og:url', content: 'https://docs.truenetwork.io/' }],
+    ['meta', { property: 'og:url', content: 'https://truenetwork.io/' }],
     ['meta', { property: 'og:title', content: 'True Network Docs: Attest & Score On-Chain Easily.' }],
-    ['meta', { property: 'og:description', content: 'True Network provides the infrastructure for dApps to give on-chain attestations & build reptuation systems easily in minutes.' }],
-    ['meta', { property: 'og:image', content: 'https://docs.truenetwork.io/og-image.png' }],
-    
+    ['meta', { property: 'og:image', content: 'https://truenetwork.io/og-image.png' }],
+    ['meta', { property: 'og:locale', content: 'en_US' }],
+
     // Twitter
     ['meta', { property: 'twitter:card', content: 'summary_large_image' }],
-    ['meta', { property: 'twitter:url', content: 'https://docs.truenetwork.io/' }],
+    ['meta', { property: 'twitter:url', content: 'https://truenetwork.io/' }],
     ['meta', { property: 'twitter:title', content: 'True Network Docs: Attest & Score On-Chain Easily.' }],
-    ['meta', { property: 'twitter:description', content: 'True Network provides the infrastructure for dApps to give on-chain attestations & build reptuation systems easily in minutes.' }],
-    ['meta', { property: 'twitter:image', content: 'https://docs.truenetwork.io/og-image.png' }],
+    ['meta', { property: 'twitter:image', content: 'https://truenetwork.io/og-image.png' }],
+    ['meta', { name: 'twitter:site', content: '@truenetworkio' }],
+    ['title', {}, 'True Network Docs: Attest & Score On-Chain Easily.'],
+    ['script', { type: 'application/ld+json' }, JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'Organization',
+      name: 'True Network',
+      url: 'https://truenetwork.io/',
+      logo: 'https://truenetwork.io/symbol.png',
+      sameAs: [
+        'https://x.com/truenetworkio',
+        'https://www.linkedin.com/company/truenetwork',
+        'https://github.com/truenetworkio'
+      ],
+      contactPoint: {
+        '@type': 'ContactPoint',
+        contactType: 'community',
+        url: 'https://at.truenetwork.io/community'
+      }
+    })],
   ],
   title: "Docs",
   
   titleTemplate: "True Network",
   description: "True Network provides the infrastructure for dApps to give on-chain attestations & build reptuation systems easily in minutes.",
+  transformHead({ page, siteData, title, description }) {
+    const hostname = 'https://truenetwork.io'
+    const canonicalUrl = `${hostname}${page}`
+    const metaDescription = description || siteData.description
+
+    const faqSchema = {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What is True Network?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'True Network provides infrastructure for dApps to publish verifiable on-chain attestations and build robust reputation systems quickly.'
+          }
+        },
+        {
+          '@type': 'Question',
+          name: 'How can I start building with True Network?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Follow the quickstart guide to learn how to create attestations, verify proofs, and plug reputation scores into your application.'
+          }
+        },
+        {
+          '@type': 'Question',
+          name: 'Where can I test True Network features?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Use the True Network Playground to experiment with attestations, reputation algorithms, and API endpoints in a guided environment.'
+          }
+        }
+      ]
+    }
+
+    const websiteSchema = {
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      url: hostname,
+      name: title || 'True Network Docs',
+      description: metaDescription,
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: `${hostname}/search?q={query}`,
+        'query-input': 'required name=query'
+      }
+    }
+
+    return [
+      ['link', { rel: 'canonical', href: canonicalUrl }],
+      ['meta', { name: 'description', content: metaDescription }],
+      ['meta', { property: 'og:description', content: metaDescription }],
+      ['meta', { property: 'twitter:description', content: metaDescription }],
+      ['script', { type: 'application/ld+json' }, JSON.stringify([websiteSchema, faqSchema])]
+    ]
+  },
   themeConfig: {
-    logo: 'https://docs.truenetwork.io/symbol.png',
+    logo: '/symbol.png',
     search: {
       provider: 'local'
     },
@@ -115,5 +196,14 @@ export default defineConfig({
       message: 'The Reputation Layer of the Internet',
       copyright: 'Copyright © 2024 Jupiter Innovations Lab Inc'
     },
+    announcementBar: {
+      id: 'docs-2024-11-updates',
+      text: 'True Network Playground just shipped reputation-ready attestations with better developer tooling.',
+      links: [
+        { label: 'Try the Playground', href: 'https://playground.truenetwork.io' },
+        { label: 'View release notes', href: 'https://at.truenetwork.io/updates' }
+      ],
+      dismissible: true
+    }
   }
 })

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -198,10 +198,9 @@ export default defineConfig({
     },
     announcementBar: {
       id: 'docs-2024-11-updates',
-      text: 'True Network Playground just shipped reputation-ready attestations with better developer tooling.',
+      text: 'Introducing Social Contracts: Using Reputation as Asset.',
       links: [
-        { label: 'Try the Playground', href: 'https://playground.truenetwork.io' },
-        { label: 'View release notes', href: 'https://at.truenetwork.io/updates' }
+        { label: 'Pragma Talk', href: 'https://youtu.be/fMJm_E96ZWE?si=y5k6dLDM3eOz3eG-' }
       ],
       dismissible: true
     }

--- a/.vitepress/theme/components/AnnouncementBar.vue
+++ b/.vitepress/theme/components/AnnouncementBar.vue
@@ -1,0 +1,144 @@
+<template>
+  <transition name="announcement-fade">
+    <div
+      v-if="hasAnnouncement && !dismissed"
+      class="announcement-bar"
+      role="status"
+      aria-live="polite"
+    >
+      <div class="announcement-inner">
+        <p class="announcement-text">
+          <span class="announcement-message">{{ text }}</span>
+          <template v-for="(link, index) in links" :key="`${link.href}-${index}`">
+            <span class="announcement-separator" aria-hidden="true">•</span>
+            <a
+              class="announcement-link"
+              :href="link.href"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {{ link.label }}
+            </a>
+          </template>
+        </p>
+        <button
+          v-if="isDismissible"
+          type="button"
+          class="announcement-dismiss"
+          aria-label="Dismiss announcement"
+          @click="dismiss"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useData } from 'vitepress'
+
+const { theme } = useData()
+
+const dismissed = ref(false)
+const announcement = computed(() => theme.value.announcementBar ?? null)
+const isDismissible = computed(() => announcement.value?.dismissible !== false)
+const storageKey = computed(() => `announcement-${announcement.value?.id ?? 'default'}`)
+const hasAnnouncement = computed(() => Boolean(announcement.value?.text))
+const text = computed(() => announcement.value?.text ?? '')
+const links = computed(() => announcement.value?.links ?? [])
+
+onMounted(() => {
+  if (!isDismissible.value) return
+
+  const alreadyDismissed = localStorage.getItem(storageKey.value) === 'dismissed'
+  dismissed.value = alreadyDismissed
+})
+
+const dismiss = () => {
+  if (!isDismissible.value) return
+
+  dismissed.value = true
+  localStorage.setItem(storageKey.value, 'dismissed')
+}
+</script>
+
+<style scoped>
+.announcement-bar {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: linear-gradient(90deg, rgba(255, 64, 0, 0.12), rgba(255, 64, 0, 0.06));
+  border-bottom: 1px solid rgba(255, 64, 0, 0.2);
+  color: var(--vp-c-text-1);
+  backdrop-filter: blur(6px);
+}
+
+.announcement-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0.75rem 1rem;
+}
+
+.announcement-text {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.announcement-message {
+  color: var(--vp-c-text-1);
+}
+
+.announcement-link {
+  color: var(--vp-c-brand-1);
+  font-weight: 700;
+  text-decoration: underline;
+  text-decoration-color: rgba(255, 64, 0, 0.35);
+  text-decoration-thickness: 2px;
+}
+
+.announcement-link:hover {
+  text-decoration-color: rgba(255, 64, 0, 0.7);
+}
+
+.announcement-separator {
+  color: rgba(0, 0, 0, 0.35);
+  padding: 0 0.25rem;
+}
+
+.announcement-dismiss {
+  background: transparent;
+  border: none;
+  color: var(--vp-c-text-1);
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+  padding: 0.25rem 0.5rem;
+  transition: color 0.2s ease;
+}
+
+.announcement-dismiss:hover {
+  color: var(--vp-c-brand-1);
+}
+
+.announcement-fade-enter-active,
+.announcement-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.announcement-fade-enter-from,
+.announcement-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/.vitepress/theme/components/AnnouncementBar.vue
+++ b/.vitepress/theme/components/AnnouncementBar.vue
@@ -66,9 +66,8 @@ const dismiss = () => {
 
 <style scoped>
 .announcement-bar {
-  position: sticky;
-  top: 0;
-  z-index: 50;
+  position: relative;
+  z-index: 1;
   background: linear-gradient(90deg, rgba(255, 64, 0, 0.12), rgba(255, 64, 0, 0.06));
   border-bottom: 1px solid rgba(255, 64, 0, 0.2);
   color: var(--vp-c-text-1);

--- a/.vitepress/theme/components/Projects.vue
+++ b/.vitepress/theme/components/Projects.vue
@@ -5,7 +5,7 @@
       {{ showAll ? 'Show Featured' : 'See All Projects' }}
     </button>
   </div>
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-4">
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-[2rem]">
     <div
       v-for="project in visibleProjects"
       :key="project.title"

--- a/.vitepress/theme/components/Projects.vue
+++ b/.vitepress/theme/components/Projects.vue
@@ -5,9 +5,6 @@
       {{ showAll ? 'Show Featured' : 'See All Projects' }}
     </button>
   </div>
-  <p class="text-sm text-[var(--vp-c-text-2)] mt-1">
-    Built on True Network — explore the community highlights or open the full list without leaving docs.
-  </p>
   <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-4">
     <div
       v-for="project in visibleProjects"

--- a/.vitepress/theme/components/Projects.vue
+++ b/.vitepress/theme/components/Projects.vue
@@ -1,12 +1,17 @@
 <template>
   <div class="flex flex-row justify-between items-center">
     <h1>Truly Awesome Apps</h1>
-    <a target="_blank" href="https://wiki.truenetwork.io/apps" class="text-sm hover:underline cursor-pointer hidden md:block">See All</a>
+    <button class="see-all" type="button" @click="toggleProjects">
+      {{ showAll ? 'Show Featured' : 'See All Projects' }}
+    </button>
   </div>
+  <p class="text-sm text-[var(--vp-c-text-2)] mt-1">
+    Built on True Network — explore the community highlights or open the full list without leaving docs.
+  </p>
   <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-4">
-    <div 
-      v-for="project in projects" 
-      :key="project.title" 
+    <div
+      v-for="project in visibleProjects"
+      :key="project.title"
       class="app-card rounded-lg overflow-hidden shadow-sm h-full flex flex-col"
     >
       <!-- Image container with fixed height -->
@@ -48,7 +53,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 
 // Define the projects with their correct data
 const projectsData = [
@@ -114,16 +119,24 @@ function shuffleArray(array) {
 
 // Use ref for reactivity
 const projects = ref([]);
+const showAll = ref(false);
+
+const visibleProjects = computed(() => (showAll.value ? projectsData : projects.value));
 
 onMounted(() => {
   // Create a shuffled list of projects that will be properly randomized
   // but maintain image consistency within a single viewing session
-  projects.value = shuffleArray(projectsData).slice(0, 3);
-  
-  // Store the selection in localStorage to persist the same projects 
+  const storedProjects = localStorage.getItem('selectedProjects');
+  projects.value = storedProjects ? JSON.parse(storedProjects) : shuffleArray(projectsData).slice(0, 3);
+
+  // Store the selection in localStorage to persist the same projects
   // across component re-renders within the same session
   localStorage.setItem('selectedProjects', JSON.stringify(projects.value));
 });
+
+const toggleProjects = () => {
+  showAll.value = !showAll.value;
+};
 </script>
 
 <style scoped>
@@ -134,5 +147,24 @@ onMounted(() => {
 .app-card:hover {
   transform: translateY(-4px);
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+}
+
+.see-all {
+  font-size: 0.9rem;
+  font-weight: 600;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  color: var(--vp-c-text-1);
+  background: #fff;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.04);
+  cursor: pointer;
+  transition: all 0.18s ease;
+}
+
+.see-all:hover {
+  border-color: rgba(255, 64, 0, 0.4);
+  color: var(--vp-c-brand-1);
+  box-shadow: 0 8px 18px rgba(255, 64, 0, 0.12);
 }
 </style>

--- a/.vitepress/theme/components/Projects.vue
+++ b/.vitepress/theme/components/Projects.vue
@@ -149,11 +149,11 @@ const toggleProjects = () => {
 .see-all {
   font-size: 0.9rem;
   font-weight: 600;
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  border: 1px solid var(--vp-c-divider);
   border-radius: 999px;
   padding: 0.35rem 0.9rem;
   color: var(--vp-c-text-1);
-  background: #fff;
+  background: var(--vp-c-bg);
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.04);
   cursor: pointer;
   transition: all 0.18s ease;
@@ -163,5 +163,16 @@ const toggleProjects = () => {
   border-color: rgba(255, 64, 0, 0.4);
   color: var(--vp-c-brand-1);
   box-shadow: 0 8px 18px rgba(255, 64, 0, 0.12);
+}
+
+:global(.dark) .see-all {
+  background: var(--vp-c-bg-alt);
+  border-color: var(--vp-c-divider);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.45);
+}
+
+:global(.dark) .see-all:hover {
+  border-color: color-mix(in srgb, var(--vp-c-brand-1) 65%, transparent);
+  box-shadow: 0 8px 18px color-mix(in srgb, var(--vp-c-brand-1) 35%, transparent);
 }
 </style>

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -3,6 +3,7 @@ import { h } from 'vue'
 import type { Theme } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
 import Carousel from './components/Carousel.vue'
+import AnnouncementBar from './components/AnnouncementBar.vue'
 import Projects from './components/Projects.vue'
 import './style.css'
 
@@ -12,6 +13,7 @@ export default {
   Layout: () => {
     return h(DefaultTheme.Layout, null, {
       // https://vitepress.dev/guide/extending-default-theme#layout-slots
+      'layout-top': () => h(AnnouncementBar)
     })
   },
   enhanceApp({ app, router, siteData }) {

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -11,9 +11,12 @@ import './style.css'
 export default {
   extends: DefaultTheme,
   Layout: () => {
+    const announcement = () => h(AnnouncementBar)
+
     return h(DefaultTheme.Layout, null, {
       // https://vitepress.dev/guide/extending-default-theme#layout-slots
-      'layout-top': () => h(AnnouncementBar)
+      'doc-before': announcement,
+      'home-hero-before': announcement
     })
   },
   enhanceApp({ app, router, siteData }) {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://truenetwork.io/sitemap.xml

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "True Network Docs",
+  "short_name": "True Docs",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ff4000",
+  "icons": [
+    {
+      "src": "/symbol.png",
+      "sizes": "908x1024",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- update site metadata, canonical host, and structured data to use truenetwork.io
- replace favicon references with the existing symbol.png asset and refresh the manifest
- refresh robots sitemap URL for the new primary domain

## Testing
- CI=1 npm run docs:build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69311bd13e5c8332b70caeeb86245a6c)